### PR TITLE
Get the checksum for all versions of OpenSSL.

### DIFF
--- a/install/haplo_plugin_install.sh
+++ b/install/haplo_plugin_install.sh
@@ -17,9 +17,13 @@ jruby_checksum="9369cfd8b19841eae2a764988121fc7d43b313b3"
 if [ -d jruby ]; then rm -r jruby; fi
 if [ -d jruby-$jruby_version ]; then rm -r jruby-$jruby_version; fi
 
+last_field() {
+  awk -F' ' '{ print $NF }'
+}
+
 jruby_checksum_matches() {
-  downloaded_checksum=`openssl sha1 < $jruby_filename`
-  [ $jruby_checksum = $downloaded_checksum ]
+  downloaded_checksum="`openssl sha1 < $jruby_filename | last_field`"
+  [ "$jruby_checksum" = "$downloaded_checksum" ]
 }
 
 download_jruby() {
@@ -39,7 +43,7 @@ fi
 
 echo "Verifying SHA1 checksum ..."
 if ! jruby_checksum_matches; then
-  echo "ERROR: SHA1 checksum mismatch, couldn't verify JRuby download"; exit
+  echo "ERROR: SHA1 checksum mismatch, couldn't verify JRuby download"; exit 1
 fi
 
 echo "Unpacking JRuby ..."


### PR DESCRIPTION
Newer versions of OpenSSL (notably, post-1.0) do not print "<checksum>" but "<algorithm>(<filename>)= <checksum>", where the algorithm is sometimes missing. In this case the file name is "stdin", so `openssl sha1 < $jruby_filename` prints:

```
(stdin)= 9369cfd8b19841eae2a764988121fc7d43b313b3
```

This change ensures we handle the hash correctly for all versions, pre- and post-1.0.
