### PR TITLE
Add excludeFromMinimisation option to developer.json

### DIFF
--- a/lib/packing.rb
+++ b/lib/packing.rb
@@ -50,7 +50,10 @@ module PluginTool
       end
       # Minimise file?
       unless filename =~ /\A(js|test)\//
-        data = minimiser.process(data, filename)
+        # Is this file explicitly excluded from minimisation during packing?
+        unless plugin.exclude_files_from_minimisation.include?(filename)
+          data = minimiser.process(data, filename)
+        end
       end
       hash = Digest::SHA256.hexdigest(data)
       # Make sure output directory exists, write file

--- a/lib/packing.rb
+++ b/lib/packing.rb
@@ -50,7 +50,7 @@ module PluginTool
       end
       # Minimise file?
       unless filename =~ /\A(js|test)\//
-        # Is this file explicitly excluded from minimisation during packing?
+        # Is this file explicitly excluded from minimisation?
         unless plugin.exclude_files_from_minimisation.include?(filename)
           data = minimiser.process(data, filename)
         end

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -191,11 +191,16 @@ module PluginTool
           hash = action
           # Minimise file before uploading?
           if @options.minimiser != nil && filename =~ /\A(static|template)\//
-            size_before = data.length
-            data = @options.minimiser.process(data, filename)
-            size_after = data.length
-            hash = Digest::SHA256.hexdigest(data)
-            puts "        minimisation: #{size_before} -> #{size_after} (#{(size_after * 100) / size_before}%)"
+            # Is this file explicitly excluded from minimisation?
+            unless exclude_files_from_minimisation.include?(filename)
+              size_before = data.length
+              data = @options.minimiser.process(data, filename)
+              size_after = data.length
+              hash = Digest::SHA256.hexdigest(data)
+              puts "        minimisation: #{size_before} -> #{size_after} (#{(size_after * 100) / size_before}%)"
+            else
+              puts "        minimisation: skipped by developer.json, unmodified file uploaded"
+            end
           end
           r = PluginTool.post_with_json_response("/api/development-plugin-loader/put-file/#{@loaded_plugin_id}", params, {:file => [filename, data]})
           if r["result"] == 'success'

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -102,6 +102,17 @@ module PluginTool
       end
     end
 
+    def exclude_files_from_minimisation
+      @exclude_files_from_minimisation ||= begin
+        # developer.json file might specify files which should skip minimisation when packing
+        if developer_json['excludeFromMinimisation'].kind_of?(Array)
+          developer_json['excludeFromMinimisation']
+        else
+          []
+        end
+      end
+    end
+
     # ---------------------------------------------------------------------------------------------------------
 
     def command(cmd, errors)


### PR DESCRIPTION
Adds the ability to specify files that should not be processed by the minimiser during plugin packing. This fixes a problem with some pre-packaged files where the minimiser causes problems, and saves time at packing time by skipping processing for already optimised files.

---

We ran into problems using some prepackaged clientside JS bundles that were working in development but breaking after being packed for production.

As these JS bundles are quite large, processing them with the minifier also takes a not insignificant amount of time for no gain, so excluding them results in a speed up during the release packing process.