### PR TITLE
Ensure check fails if @@check_ok is false

### DIFF
--- a/lib/check.rb
+++ b/lib/check.rb
@@ -22,7 +22,7 @@ module PluginTool
     puts
     if @@check_ok && !@@check_warn
       puts "PASSED"
-    elsif @@check_warn
+    elsif @@check_ok && @@check_warn
       puts "PASSED WITH WARNINGS"
     else
       puts "FAILED"


### PR DESCRIPTION
Fixes a problem where if check_ok is false, but check_warn is true, the check operation returns 'PASSED WITH WARNINGS' despite some files indicating errors/fails.

Resolves #5